### PR TITLE
Change logger function to not allow verbose message to fall through and get logged as notice messages

### DIFF
--- a/haproxy.py
+++ b/haproxy.py
@@ -176,8 +176,9 @@ def logger(t, msg):
         collectd.error('%s: %s' % (NAME, msg))
     elif t == 'warn':
         collectd.warning('%s: %s' % (NAME, msg))
-    elif t == 'verb' and VERBOSE_LOGGING:
-        collectd.info('%s: %s' % (NAME, msg))
+    elif t == 'verb':
+        if VERBOSE_LOGGING:
+            collectd.info('%s: %s' % (NAME, msg))
     else:
         collectd.notice('%s: %s' % (NAME, msg))
 


### PR DESCRIPTION
- Changed the VERBOSE_LOGGING check in the logger function to be nested
  inside the message type check. This prevents the else clause from
  executing if message type 'verb' and VERBOSE_LOGGING is false.
