### PR TITLE
organise metrics by plugin instance

### DIFF
--- a/haproxy.py
+++ b/haproxy.py
@@ -165,9 +165,9 @@ def read_callback():
       continue
 
     key_root, val_type = METRIC_TYPES[key_root]
-    key_name = METRIC_DELIM.join([key_prefix, key_root])
     val = collectd.Values(plugin=NAME, type=val_type)
-    val.type_instance = key_name
+    val.plugin_instance = key_prefix
+    val.type_instance = key_root
     val.values = [ value ]
     val.dispatch()
 


### PR DESCRIPTION
This basically adds an additional level of "hierarchy" to the haproxy metrics in graphite, to separate them based on the "server" settings defined in haproxy.cfg. ie:
- before: `collectd.<hostname>.haproxy.gauge-main_website_session_current`
- after: `collectd.<hostname>.haproxy-main_website.gauge-session_current`

...for an haproxy config such as:

```
backend website
  balance roundrobin
  server  main     1.2.3.4:80 check inter 5000 downinter 500
  server  failover  5.6.7.8:80 check inter 5000 backup
```
