### PR TITLE
Add Python 3 support

### DIFF
--- a/haproxy.py
+++ b/haproxy.py
@@ -77,7 +77,7 @@ class HAProxySocket(object):
     for line in output.splitlines():
       try:
         key,val = line.split(':')
-      except ValueError, e:
+      except ValueError as e:
         continue
       result[key.strip()] = val.strip()
     return result
@@ -98,7 +98,7 @@ def get_stats():
   try:
     server_info = haproxy.get_server_info()
     server_stats = haproxy.get_server_stats()
-  except socket.error, e:
+  except socket.error as e:
     logger('warn', "status err Unable to connect to HAProxy socket at %s" % HAPROXY_SOCKET)
     return stats
 
@@ -106,7 +106,7 @@ def get_stats():
     for key,val in server_info.items():
       try:
         stats[key] = int(val)
-      except (TypeError, ValueError), e:
+      except (TypeError, ValueError) as e:
         pass
 
   for statdict in server_stats:
@@ -118,7 +118,7 @@ def get_stats():
       metricname = METRIC_DELIM.join([ statdict['svname'].lower(), statdict['pxname'].lower(), key ])
       try:
         stats[metricname] = int(val)
-      except (TypeError, ValueError), e:
+      except (TypeError, ValueError) as e:
         pass
   return stats
 
@@ -159,7 +159,7 @@ def read_callback():
     if not value in METRIC_TYPES:
       try:
         key_prefix, key_root = key.rsplit(METRIC_DELIM,1)
-      except ValueError, e:
+      except ValueError as e:
         pass
     if not key_root in METRIC_TYPES:
       continue

--- a/haproxy.py
+++ b/haproxy.py
@@ -61,12 +61,12 @@ class HAProxySocket(object):
     ''' Send a single command to the socket and return a single response (raw string) '''
     s = self.connect()
     if not command.endswith('\n'): command += '\n'
-    s.send(command)
+    s.send(command.encode())
     result = ''
     buf = ''
     buf = s.recv(RECV_SIZE)
     while buf:
-      result += buf
+      result += buf.decode()
       buf = s.recv(RECV_SIZE)
     s.close()
     return result


### PR DESCRIPTION
This MR:

* encodes/decodes strings to/from bytes when talking to the HAProxy socket
* tweaks the `try` … `except` syntax

both of which make the plugin work under Python 3.

This addresses the following logged exceptions:

```
Unhandled python exception in importing module: SyntaxError: invalid syntax
Unhandled python exception in read callback: TypeError: a bytes-like object is required, not 'str'
Unhandled python exception in read callback: TypeError: must be str, not bytes
```

Disclaimer: my Python skills are very limited, but this fixed it for me.